### PR TITLE
Fix for long Indels

### DIFF
--- a/src/dwgsim.c
+++ b/src/dwgsim.c
@@ -114,7 +114,7 @@ uint8_t nst_nt4_table[256] = {
                 uint8_t *insertion = NULL; \
                 insertion = mut_get_ins_long_n(currseq->ins[ins], &num_ins); \
                 if(0 == strand[x]) { \
-                    byte_index = mut_packed_len(num_ins)-1; bit_index = num_ins & 3; \
+                    byte_index = mut_packed_len(num_ins)-1; bit_index = (num_ins - 1) & 3; \
                     while(num_ins > 0 && k < s[x]) { \
                         tmp_seq[x][k++] = (insertion[byte_index] >> (bit_index << 1)) & 0x3;                \
                         --num_ins, ins >>= 2; \


### PR DESCRIPTION
1) Fix: Position of long indels was affected by read orientation
2) Fix: Make VCF file better match to VCFs generated by samtools & bcfutils.
3) Don't mutate base 0 of reference to avoid VCF format problem for indels.
