### PR TITLE
Fix link error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ all:$(PROG)
 .PHONY:all-recur lib-recur clean-recur cleanlocal-recur install-recur
 
 dwgsim:lib-recur $(DWGSIM_AOBJS)
-	$(CC) $(CFLAGS) -o $@ $(DWGSIM_AOBJS) -lm -lz
+	$(CC) $(CFLAGS) -o $@ $(DWGSIM_AOBJS) -lm -lz -lpthread
 
 dwgsim_eval:lib-recur $(DWGSIM_EVAL_AOBJS)
-	$(CC) $(CFLAGS) -o $@ $(DWGSIM_EVAL_AOBJS) -Lsamtools -lm -lz
+	$(CC) $(CFLAGS) -o $@ $(DWGSIM_EVAL_AOBJS) -Lsamtools -lm -lz -lpthread
 
 cleanlocal:
 		rm -vfr gmon.out *.o a.out *.exe *.dSYM razip bgzip $(PROG) *~ *.a *.so.* *.so *.dylib; \


### PR DESCRIPTION
On my setup (Ubuntu 12.04, gcc 4.6.3) linking fails unless -lpthread is explicitly passed to the linker
