### PR TITLE
mut_get_ins_long_n: Not inline

### DIFF
--- a/src/mut.c
+++ b/src/mut.c
@@ -197,7 +197,7 @@ mut_get_ins_bytes(int32_t n)
   return num_bytes;
 }
 
-inline uint8_t*
+uint8_t*
 mut_get_ins_long_n(uint8_t *ins, uint32_t *n)
 {
   switch(ins[0]) {


### PR DESCRIPTION
Fix this error:
gcc -g -Wall -O2  -o dwgsim src/dwgsim_opt.o src/mut.o src/contigs.o src/regions_bed.o src/mut_txt.o src/mut_bed.o src/mut_vcf.o src/mut_input.o src/dwgsim.o -lm -lz
Undefined symbols for architecture x86_64:
  "_mut_get_ins_long_n", referenced from:
      _dwgsim_core in dwgsim.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
