### PR TITLE
Travis-ci: added support for ppc64le along with amd64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,8 @@ language: c
 compiler:
 - clang
 - gcc
+
+arch:
+  - amd64
+  - ppc64le
 script: make && make test


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/DWGSIM/builds/187628853 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!