### PR TITLE
fix: prevent integer overflow and negative distance in position calculation

### DIFF
--- a/src/dwgsim.c
+++ b/src/dwgsim.c
@@ -646,14 +646,21 @@ void dwgsim_core(dwgsim_opt_t * opt)
                               ran = ran_normal();
                               ran = ran * opt->std_dev + opt->dist;
                               d = (int)(ran + 0.5);
+                              // Clamp d to valid range to prevent overflow
+                              int min_dist = s[0] + s[1];
+                              if (d < min_dist) d = min_dist;
+                              if (d > l) d = l;
                           }
                           else {
                               d = 0;
                           }
-                          pos = (int)((l - d + 1) * drand48());
-                      } while (pos < 0 
-                               || pos >= seq.l 
-                               || pos + d - 1 >= seq.l 
+                          // Use 64-bit arithmetic to prevent overflow
+                          int64_t range = (int64_t)l - d + 1;
+                          if (range <= 0) continue;
+                          pos = (int)(range * drand48());
+                      } while (pos < 0
+                               || pos >= seq.l
+                               || pos + d - 1 >= seq.l
                                || (0 < s[1] && 0 == opt->is_inner && ((0 < s[0] && d <= s[1]) || (d <= s[0] && 0 < s[1]))));
                   } 
                   else {
@@ -662,11 +669,18 @@ void dwgsim_core(dwgsim_opt_t * opt)
                               ran = ran_normal();
                               ran = ran * opt->std_dev + opt->dist;
                               d = (int)(ran + 0.5);
+                              // Clamp d to valid range to prevent overflow
+                              int min_dist = s[0] + s[1];
+                              if (d < min_dist) d = min_dist;
+                              if (d > l) d = l;
                           }
                           else {
                               d = 0;
                           }
-                          pos = (int)((l - d + 1) * drand48());
+                          // Use 64-bit arithmetic to prevent overflow
+                          int64_t range = (int64_t)l - d + 1;
+                          if (range <= 0) continue;
+                          pos = (int)(range * drand48());
                           // convert in the bed file
                           for(i=0;i<regions_bed->n;i++) { // TODO: regions are in sorted order... so optimize
                               if(contig_i == regions_bed->contig[i]) {


### PR DESCRIPTION
## Summary
- Clamp distance `d` to valid range to prevent negative/invalid values from normal distribution
- Use 64-bit arithmetic for range calculation to prevent integer overflow
- Skip iteration if calculated range is invalid

Closes #96

## Root Cause
When generating paired-end reads, the distance `d` is calculated from a normal distribution. With extreme values (e.g., -10 sigma), `d` can become negative, causing:
1. The expression `(l - d + 1)` to overflow
2. Reads to be generated from incorrect positions

## Changes
Both occurrences in `dwgsim_core()` are fixed:
- Lines 646-660 (standard case)
- Lines 669-683 (regions_bed case)

## Test plan
- [ ] Verify build succeeds
- [ ] Run integration tests (`make test-integration`)
- [ ] Manually test with high std_dev values to verify no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)