### PR TITLE
fix: prevent use-after-free risk in dual reallocation

### DIFF
--- a/src/dwgsim.c
+++ b/src/dwgsim.c
@@ -294,12 +294,16 @@ generate_errors_flows(dwgsim_opt_t *opt, uint8_t **seq, uint8_t **mask, int32_t 
                       uint8_t *temp_seq, *temp_mask;
                       (*mem) <<= 1; // double
                       temp_seq = realloc((*seq), sizeof(uint8_t) * (*mem));
-                      temp_mask = realloc((*mask), sizeof(uint8_t) * (*mem));
-                      if(NULL == temp_seq || NULL == temp_mask) {
-                          fprintf(stderr, "Error: memory allocation failed in generate_errors_flows\n");
+                      if(NULL == temp_seq) {
+                          fprintf(stderr, "Error: memory allocation failed for seq in generate_errors_flows\n");
                           exit(1);
                       }
                       (*seq) = temp_seq;
+                      temp_mask = realloc((*mask), sizeof(uint8_t) * (*mem));
+                      if(NULL == temp_mask) {
+                          fprintf(stderr, "Error: memory allocation failed for mask in generate_errors_flows\n");
+                          exit(1);
+                      }
                       (*mask) = temp_mask;
                   }
                   // shift up
@@ -371,12 +375,16 @@ generate_errors_flows(dwgsim_opt_t *opt, uint8_t **seq, uint8_t **mask, int32_t 
                   uint8_t *temp_seq, *temp_mask;
                   (*mem) <<= 1; // double
                   temp_seq = realloc((*seq), sizeof(uint8_t) * (*mem));
-                  temp_mask = realloc((*mask), sizeof(uint8_t) * (*mem));
-                  if(NULL == temp_seq || NULL == temp_mask) {
-                      fprintf(stderr, "Error: memory allocation failed in generate_errors_flows\n");
+                  if(NULL == temp_seq) {
+                      fprintf(stderr, "Error: memory allocation failed for seq in generate_errors_flows\n");
                       exit(1);
                   }
                   (*seq) = temp_seq;
+                  temp_mask = realloc((*mask), sizeof(uint8_t) * (*mem));
+                  if(NULL == temp_mask) {
+                      fprintf(stderr, "Error: memory allocation failed for mask in generate_errors_flows\n");
+                      exit(1);
+                  }
                   (*mask) = temp_mask;
               }
               // shift up


### PR DESCRIPTION
## Summary
- Check each realloc return value immediately before the next allocation
- Fixed in both occurrences in `generate_errors_flows()`

Closes #98

## Test plan
- [ ] Build succeeds
- [ ] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and reporting for memory allocation failures, providing more granular diagnostic messages when buffer expansion encounters issues during data processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->