### PR TITLE
fix: prevent buffer overrun in fscanf/sscanf string parsing

### DIFF
--- a/src/mut_bed.c
+++ b/src/mut_bed.c
@@ -52,7 +52,7 @@ muts_bed_t *muts_bed_init(FILE *fp, contigs_t *c)
   i = 0;
   // start is zero-based
   // one is one-based
-  while(0 < fscanf(fp, "%s\t%u\t%u\t%s\t%s", name, &start, &end, bases, type)) {
+  while(0 < fscanf(fp, "%1023s\t%u\t%u\t%1023s\t%1023s", name, &start, &end, bases, type)) {
       // find the contig
       while(i < c->n && 0 != strcmp(name, c->contigs[i].name)) {
           i++;

--- a/src/mut_txt.c
+++ b/src/mut_txt.c
@@ -51,7 +51,7 @@ muts_txt_t *muts_txt_init(FILE *fp, contigs_t *c)
   m->muts = malloc(m->mem * sizeof(mut_txt_t));
 
   i = 0;
-  while(0 < fscanf(fp, "%s\t%u\t%c\t%s\t%d", name, &pos, &ref, mut, &is_hap)) {
+  while(0 < fscanf(fp, "%1023s\t%u\t%c\t%1023s\t%d", name, &pos, &ref, mut, &is_hap)) {
       // find the contig
       while(i < c->n && 0 != strcmp(name, c->contigs[i].name)) {
           i++;

--- a/src/mut_vcf.c
+++ b/src/mut_vcf.c
@@ -85,7 +85,7 @@ muts_vcf_t *muts_vcf_init(FILE *fp, contigs_t *c)
           }
 
           // process
-          if(EOF == sscanf(buffer+s, "%s\t%u\t%s\t%s\t%s", name, &pos, id, ref, alt)) {
+          if(EOF == sscanf(buffer+s, "%1023s\t%u\t%1023s\t%1023s\t%1024s", name, &pos, id, ref, alt)) {
               fprintf(stderr, "Error: VCF parsing error\n"); 
               exit(1);
           }

--- a/src/regions_bed.c
+++ b/src/regions_bed.c
@@ -51,7 +51,7 @@ regions_bed_txt *regions_bed_init(FILE *fp, contigs_t *c)
   
   i = 0;
   prev_contig = prev_start = prev_end = -1;
-  while(0 < fscanf(fp, "%s\t%u\t%u", name, &start, &end)) {
+  while(0 < fscanf(fp, "%1023s\t%u\t%u", name, &start, &end)) {
       len = end - start + 1;
       // find the contig
       while(i < c->n && 0 != strcmp(name, c->contigs[i].name)) {


### PR DESCRIPTION
## Summary
Add field width specifiers to %s format strings to prevent buffer overflow.

Files fixed:
- mut_txt.c: %1023s for name and mut fields
- mut_vcf.c: %1023s/%1024s for name, id, ref, alt fields  
- mut_bed.c: %1023s for name, bases, type fields
- regions_bed.c: %1023s for name field

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved input parsing robustness across multiple file format handlers (BED, TXT, VCF) to better handle and constrain input field sizes, ensuring more stable data processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->