### PR TITLE
fix: correct BED coordinate system calculation

### DIFF
--- a/src/dwgsim.c
+++ b/src/dwgsim.c
@@ -498,7 +498,7 @@ void dwgsim_core(dwgsim_opt_t * opt)
       // recalculate the total length
       tot_len = 0;
       for(i=0;i<regions_bed->n;i++) {
-          tot_len += regions_bed->end[i] - regions_bed->start[i] + 1;
+          tot_len += regions_bed->end[i] - regions_bed->start[i];  // BED half-open
       }
   }
   if(NULL != contigs) {
@@ -538,7 +538,7 @@ void dwgsim_core(dwgsim_opt_t * opt)
                   m = 0;
                   for(i=0;i<regions_bed->n;i++) {
                       if(contig_i == regions_bed->contig[i]) {
-                          m += regions_bed->end[i] - regions_bed->start[i] + 1;
+                          m += regions_bed->end[i] - regions_bed->start[i];  // BED half-open
                       }
                   }
                   if(0 == m) {
@@ -692,7 +692,7 @@ void dwgsim_core(dwgsim_opt_t * opt)
                           // convert in the bed file
                           for(i=0;i<regions_bed->n;i++) { // TODO: regions are in sorted order... so optimize
                               if(contig_i == regions_bed->contig[i]) {
-                                  j = regions_bed->end[i] - regions_bed->start[i] + 1;
+                                  j = regions_bed->end[i] - regions_bed->start[i];  // BED half-open
                                   if(pos < j) {
                                       pos = regions_bed->start[i] + pos - 1; // zero-based
                                       break;

--- a/src/regions_bed.c
+++ b/src/regions_bed.c
@@ -52,7 +52,7 @@ regions_bed_txt *regions_bed_init(FILE *fp, contigs_t *c)
   i = 0;
   prev_contig = prev_start = prev_end = -1;
   while(0 < fscanf(fp, "%1023s\t%u\t%u", name, &start, &end)) {
-      len = end - start + 1;
+      len = end - start;  // BED is 0-based, half-open [start, end)
       // find the contig
       while(i < c->n && 0 != strcmp(name, c->contigs[i].name)) {
           i++;
@@ -78,8 +78,8 @@ regions_bed_txt *regions_bed_init(FILE *fp, contigs_t *c)
           exit(1);
       }
       
-      if(end - start + 1 != len) {
-          fprintf(stderr, "Warning: len != end - start + 1 [%s,%u,%u,%u]\n", name, start, end, len);
+      if(end - start != len) {
+          fprintf(stderr, "Warning: len != end - start [%s,%u,%u,%u]\n", name, start, end, len);
       }
       
       if(prev_contig == i && start <= prev_end && prev_start <= start) {


### PR DESCRIPTION
## Summary
BED format uses 0-based, half-open intervals [start, end).
Changed length calculation from `end - start + 1` to `end - start`.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed BED file interval coordinate handling to comply with standard genomic conventions. This improves the accuracy of region length calculations, validation checks, and position processing across all genomic operations. The changes ensure consistent and precise handling of genomic intervals from BED file inputs throughout the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->